### PR TITLE
Move the PayPal configuration to AppSettings

### DIFF
--- a/Source/Web Sites/Link.BA.Donate.WebSite/Controllers/DonationController.cs
+++ b/Source/Web Sites/Link.BA.Donate.WebSite/Controllers/DonationController.cs
@@ -20,6 +20,7 @@ using PayPal.Api;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.DataContracts;
+using System.Web.Configuration;
 
 namespace Link.BA.Donate.WebSite.Controllers
 {
@@ -559,6 +560,15 @@ namespace Link.BA.Donate.WebSite.Controllers
             return null;
         }
 
+        private Dictionary<string, string> GetPayPalConfiguration()
+        {
+            Dictionary<string, string> result = new Dictionary<string, string>();
+            result.Add("mode", WebConfigurationManager.AppSettings["PayPal.mode"]);
+            result.Add("clientId", WebConfigurationManager.AppSettings["PayPal.clientId"]);
+            result.Add("clientSecret", WebConfigurationManager.AppSettings["PayPal.clientSecret"]);
+            return result;
+        }
+
         [HandleError]
         [ValidateAntiForgeryToken]
         [HttpPost]
@@ -566,18 +576,18 @@ namespace Link.BA.Donate.WebSite.Controllers
         {
             ActionResult result = null;
 
-            var config = ConfigManager.Instance.GetProperties();
+            var config = GetPayPalConfiguration();
             var accessToken = new OAuthTokenCredential(config).GetAccessToken();
             var apiContext = new APIContext(accessToken);
 
 
             var payer = new Payer() { payment_method = "paypal" };
 
-                var redirUrls = new RedirectUrls
-                {
-                    cancel_url = string.Format("{0}://{1}{2}", Request.Url.Scheme, Request.Url.Authority, ConfigurationManager.AppSettings["PayPal.CancelUrl"]),
-                    return_url = string.Format("{0}://{1}{2}", Request.Url.Scheme, Request.Url.Authority, ConfigurationManager.AppSettings["PayPal.ReturnUrl"])
-                };
+            var redirUrls = new RedirectUrls
+            {
+                cancel_url = string.Format("{0}://{1}{2}", Request.Url.Scheme, Request.Url.Authority, ConfigurationManager.AppSettings["PayPal.CancelUrl"]),
+                return_url = string.Format("{0}://{1}{2}", Request.Url.Scheme, Request.Url.Authority, ConfigurationManager.AppSettings["PayPal.ReturnUrl"])
+            };
 
             var itemList = new ItemList
             {
@@ -638,7 +648,7 @@ namespace Link.BA.Donate.WebSite.Controllers
                 .Where(p => p.rel.ToLowerInvariant() == "approval_url")
                 .FirstOrDefault();
 
-            if(link != null)
+            if (link != null)
             {
                 result = Redirect(link.href);
             }
@@ -763,7 +773,7 @@ namespace Link.BA.Donate.WebSite.Controllers
         {
             try
             {
-                var config = ConfigManager.Instance.GetProperties();
+                var config = GetPayPalConfiguration();
                 var accessToken = new OAuthTokenCredential(config).GetAccessToken();
                 var apiContext = new APIContext(accessToken);
 

--- a/Source/Web Sites/Link.BA.Donate.WebSite/Web.config
+++ b/Source/Web Sites/Link.BA.Donate.WebSite/Web.config
@@ -5,7 +5,6 @@
   -->
 <configuration>
   <configSections>
-    <section name="paypal" type="PayPal.SDKConfigHandler, PayPal" />
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
@@ -104,6 +103,9 @@
     <add key="Sibs.Entity" value="11624" />
     <add key="PayPal.CancelUrl" value="/"/>
     <add key="PayPal.ReturnUrl" value="/Donation/ReferencePayedViaPayPal"/>
+    <add key="PayPal.mode" value="sandbox" />
+    <add key="PayPal.clientId" value="AePQ-xRffzwwqEEiMIljRwpey_DyBBogCqJuKzrrwPpkOIw7b2P8XNWxCoKvtzVwJpNgtJH42t5wYZY9" />
+    <add key="PayPal.clientSecret" value="EACY-FRYatsqMXnwgT8A2oEteiEBfkv0DqAAd0D_n7AEiazsS8JxZIYhnBAFeR8FyYkla3bDXRtFtlLm" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -246,13 +248,6 @@
       <add name="Microsoft SQL Server Compact Edition Client Data Provider 4.0" invariant="System.Data.SqlServerCe.4.0" description=".NET Framework Data Provider for Microsoft SQL Server Compact Edition Client 4.0" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91" />
     </DbProviderFactories>
   </system.data>
-  <paypal>
-    <settings>
-      <add name="mode" value="sandbox" />
-      <add name="clientId" value="AePQ-xRffzwwqEEiMIljRwpey_DyBBogCqJuKzrrwPpkOIw7b2P8XNWxCoKvtzVwJpNgtJH42t5wYZY9" />
-      <add name="clientSecret" value="EACY-FRYatsqMXnwgT8A2oEteiEBfkv0DqAAd0D_n7AEiazsS8JxZIYhnBAFeR8FyYkla3bDXRtFtlLm" />
-    </settings>
-  </paypal>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>


### PR DESCRIPTION
Remove the configuration section of PayPal and integrated into the AppSetting. This is because we want to managed that from Azure App Service Plan. 
Next step is to remove those settings in the web.config and setup this on the Web App in Azure. 