### PR TITLE
Display a note when the reset password is requested and the email is not confirmed

### DIFF
--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -60,7 +60,7 @@ namespace BancoAlimentar.AlimentaEstaIdeia.Web.Areas.Identity.Pages.Account
                 if (user == null || !(await userManager.IsEmailConfirmedAsync(user)))
                 {
                     // Don't reveal that the user does not exist or is not confirmed
-                    return RedirectToPage("./ForgotPasswordConfirmation");
+                    return RedirectToPage("./ForgotPasswordConfirmation", "WithEmailNotConfirmedNote");
                 }
 
                 // For more information on how to enable account confirmation and password reset please

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml
@@ -1,11 +1,19 @@
 ﻿@page
 @model ForgotPasswordConfirmation
 @{
-    ViewData["Title"] = IdentitySharedLocalizer["ForgotPasswordConfirmation"];
+  ViewData["Title"] = IdentitySharedLocalizer["ForgotPasswordConfirmation"];
 }
 
 <h1>@ViewData["Title"]</h1>
-<p>
-    @IdentitySharedLocalizer["ForgotPasswordConfirmationMessage"]
-</p>
+<div class="alert alert-success" role="alert">
+  @IdentitySharedLocalizer["ForgotPasswordConfirmationMessage"]
+</div>
+
+@if (Model.DisplayEmailNotConfirmedNote)
+{
+  <div class="alert alert-warning" role="alert">
+    <h5 class="alert-heading">@IdentitySharedLocalizer["ForgotPasswordConfirmationNoteHeader"]</h5>
+    <p>@IdentitySharedLocalizer["ForgotPasswordConfirmationNoteText"] <a asp-page="./ResendEmailConfirmation" class="alert-link">@IdentitySharedLocalizer["ForgotPasswordConfirmationNoteTextClickHere"]</a>.</p>
+  </div>
+}
 

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
@@ -16,10 +16,23 @@ namespace BancoAlimentar.AlimentaEstaIdeia.Web.Areas.Identity.Pages.Account
     public class ForgotPasswordConfirmation : PageModel
     {
         /// <summary>
+        /// Gets a value indicating whether the page containing the email not confirmed note is shown.
+        /// </summary>
+        public bool DisplayEmailNotConfirmedNote { get; private set; }
+
+        /// <summary>
         /// Execute the get operation.
         /// </summary>
         public void OnGet()
         {
         }
-    }
+
+        /// <summary>
+        /// Execute the get operation with email not confirmed note.
+        /// </summary>
+        public void OnGetWithEmailNotConfirmedNote()
+        {
+          DisplayEmailNotConfirmedNote = true;
+        }
+  }
 }

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.en.resx
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.en.resx
@@ -342,4 +342,13 @@
   <data name="Payed" xml:space="preserve">
     <value>Payed</value>
   </data>
+  <data name="ForgotPasswordConfirmationNoteHeader" xml:space="preserve">
+    <value>Note</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteTextClickHere" xml:space="preserve">
+    <value>here</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteText" xml:space="preserve">
+    <value>If you have not confirmed your email, you will not be able to reset your password. You can request the confirmation email</value>
+  </data>
 </root>

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.es.resx
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.es.resx
@@ -342,4 +342,13 @@
   <data name="Payed" xml:space="preserve">
     <value>Pagado</value>
   </data>
+  <data name="ForgotPasswordConfirmationNoteTextClickHere" xml:space="preserve">
+    <value>aquí</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteHeader" xml:space="preserve">
+    <value>Nota</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteText" xml:space="preserve">
+    <value>Si no ha confirmado su correo electrónico, no podrá restablecer su contraseña. ¡Puede solicitar la reenvío del correo electrónico de confirmación</value>
+  </data>
 </root>

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.fr.resx
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.fr.resx
@@ -342,4 +342,13 @@
   <data name="Payed" xml:space="preserve">
     <value>Payé</value>
   </data>
+  <data name="ForgotPasswordConfirmationNoteTextClickHere" xml:space="preserve">
+    <value>ici</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteHeader" xml:space="preserve">
+    <value>Note</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteText" xml:space="preserve">
+    <value>Si vous n’avez pas confirmé votre e-mail, vous ne pourrez pas réinitialiser votre mot de passe. Vous pouvez demander la nouvelle soumission de l’e-mail de confirmation</value>
+  </data>
 </root>

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.pt.resx
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.pt.resx
@@ -339,4 +339,16 @@
   <data name="Payed" xml:space="preserve">
     <value>Pago</value>
   </data>
+  <data name="ForgotPasswordConfirmationNoteTextClickHere" xml:space="preserve">
+    <value>aqui</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Volte à gestão de perfis.!</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteHeader" xml:space="preserve">
+    <value>Nota</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteText" xml:space="preserve">
+    <value>Em caso de não ter confirmado o seu e-mail, não será possível redefinir a sua password. Pode solicitar o reenvio do e-mail de confirmação</value>
+  </data>
 </root>

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.resx
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Resources/IdentitySharedResources.resx
@@ -330,4 +330,13 @@
   <data name="Back" xml:space="preserve">
     <value>Volte à gestão de perfis.</value>
   </data>
+  <data name="ForgotPasswordConfirmationNoteHeader" xml:space="preserve">
+    <value>Nota</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteText" xml:space="preserve">
+    <value>Em caso de não ter confirmado o seu e-mail, não será possível redefinir a sua password. Pode solicitar o reenvio do e-mail de confirmação</value>
+  </data>
+  <data name="ForgotPasswordConfirmationNoteTextClickHere" xml:space="preserve">
+    <value>aqui</value>
+  </data>
 </root>


### PR DESCRIPTION
# Description

When the user request to reset the password and doesn't have confirmed the email yet, display a warning note informing the user that first should confirm the email.

Fixes #535 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual tests Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Register an account. Before confirming the email, request to reset the password, and the warning note should appear.
- [x] Register an account. After confirming the email, request to reset the password, and the warning should not appear.
