### PR TITLE
Fix facebook pixel code and remove the old ID

### DIFF
--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Pages/Shared/_Layout.cshtml
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Pages/Shared/_Layout.cshtml
@@ -75,9 +75,8 @@
 			}(window, document, 'script',
 				'https://connect.facebook.net/en_US/fbevents.js');
 
-			fbq('init', '553983925045985'); //Criado por Brandkey !?
 			fbq('init', '508607333446877'); //criado por Tiago 2020.12.14 na conta do Facebook Business do Banco Alimentar
-			tSesIdsionessionession  fbq(Session'track', 'PageView');
+			fbq('track', 'PageView');
 		</script>
 		<noscript>
 			<img height="1" width="1"


### PR DESCRIPTION
# Description

The javascript code containing the facebook pixel information was wrongly formatted and contained not recognized code.

Remove the old pixel ID

Fixes #669 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
