### PR TITLE
Fix usage of culture dependent values to do the calculations

### DIFF
--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Pages/ClaimInvoice.cshtml
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Pages/ClaimInvoice.cshtml
@@ -36,7 +36,7 @@
 				</div>
 				<div class="half2 margin2 fixMobile101">
 					
-					<span id="total" contenteditable="true" class="text8" style="display:none">0.00€</span>
+					<span id="total" contenteditable="true" class="text8" style="display:none">0.00 €</span>
 					<div class="clearSimple"></div>
 					
 				</div>

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/Pages/Donation.cshtml
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/Pages/Donation.cshtml
@@ -148,7 +148,7 @@
                 </div>
                 <div class="half2 margin2 fixMobile101">
                     <span class="text7">@Localizer["Total"]</span>
-                    <span id="total" contenteditable="true" class="text8">0.00€</span>
+                    <span id="total" contenteditable="true" class="text8">0.00 €</span>
                     <div class="clearSimple"></div>
                     <span class="text9">@Localizer["VerCabaz"]</span>
                 </div>

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/wwwroot/js/custom.js
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/wwwroot/js/custom.js
@@ -169,7 +169,7 @@ $(document).ready(function () {
 
         // update totals
         if (value > 0) {
-            addItemToCard(this, value);
+            addItemTocart(this, value);
             $(this).parent().find('input').addClass("positive");
         } else {
             $(this).parent().find('input').removeClass("positive");
@@ -184,7 +184,7 @@ $(document).ready(function () {
 
         // update totals
         if (parseInt(value) >= 0) {
-            removeItemFromCard(this, value);
+            removeItemFromcart(this, value);
             $(this).parent().find('input').addClass("positive");
         }
         if (parseInt(value) <= 0) {
@@ -332,7 +332,7 @@ function formatCoin(value) {
  * @param {object} element The element that is affected
  * @param {number} value The new value for the item
  */
-function addItemToCard(element, value) {
+function addItemTocart(element, value) {
     updateCartItemValuesAndQuantities(element, value, "add");
 }
 
@@ -341,12 +341,12 @@ function addItemToCard(element, value) {
  * @param {object} element The element that is affected
  * @param {number} value The new value for the item
  */
-function removeItemFromCard(element, value) {
+function removeItemFromcart(element, value) {
     updateCartItemValuesAndQuantities(element, value, "remove");
 }
 
 /**
- * Update a card item, means, the quantity and total amount
+ * Update a cart item, means, the quantity and total amount
  * @param {object} element The element that is affected
  * @param {number} value The new value for the item
  * @param {string} strategy The startegy for the update, at the moment only add and remove
@@ -377,12 +377,12 @@ function updateNewAmountElements(newAmount) {
 }
 
 /**
- * Update a card item
- * @param {string} cardItem The item that will be updated
+ * Update a cart item
+ * @param {string} cartItem The item that will be updated
  * @param {number} value The new value
  */
-function updateCartItemElement(cardItem, value) {
-    $(cardItem).html(roundToTwoFractionDigitsNoLocale(value));
+function updateCartItemElement(cartItem, value) {
+    $(cartItem).html(roundToTwoFractionDigitsNoLocale(value));
 }
 
 /**

--- a/BancoAlimentar.AlimentaEstaIdeia.Web/wwwroot/js/custom.js
+++ b/BancoAlimentar.AlimentaEstaIdeia.Web/wwwroot/js/custom.js
@@ -169,7 +169,7 @@ $(document).ready(function () {
 
         // update totals
         if (value > 0) {
-            addItemTocart(this, value);
+            addItemToCart(this, value);
             $(this).parent().find('input').addClass("positive");
         } else {
             $(this).parent().find('input').removeClass("positive");
@@ -184,7 +184,7 @@ $(document).ready(function () {
 
         // update totals
         if (parseInt(value) >= 0) {
-            removeItemFromcart(this, value);
+            removeItemFromCart(this, value);
             $(this).parent().find('input').addClass("positive");
         }
         if (parseInt(value) <= 0) {
@@ -332,7 +332,7 @@ function formatCoin(value) {
  * @param {object} element The element that is affected
  * @param {number} value The new value for the item
  */
-function addItemTocart(element, value) {
+function addItemToCart(element, value) {
     updateCartItemValuesAndQuantities(element, value, "add");
 }
 
@@ -341,7 +341,7 @@ function addItemTocart(element, value) {
  * @param {object} element The element that is affected
  * @param {number} value The new value for the item
  */
-function removeItemFromcart(element, value) {
+function removeItemFromCart(element, value) {
     updateCartItemValuesAndQuantities(element, value, "remove");
 }
 


### PR DESCRIPTION
# Description
The values used for calculations are now culture-independent.
This is a shortcut for a possible final solution because is a bug present in production.
Is necessary to move some values to data attributes and then is possible to display the values to the user with the user culture and to use the culture-independent for the calculations.

Some To-Do was added to the file.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #667 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
