### PR TITLE
Fix admin function queue binding

### DIFF
--- a/BancoAlimentar.AlimentaEstaIdeia.Function/AdminFunctionExecutionQueueTrigger.cs
+++ b/BancoAlimentar.AlimentaEstaIdeia.Function/AdminFunctionExecutionQueueTrigger.cs
@@ -44,7 +44,7 @@ namespace BancoAlimentar.AlimentaEstaIdeia.Function
         /// <returns>A task object to monitor progress.</returns>
         [Function("AdminFunctionExecutionQueueTrigger")]
         public async Task Run(
-            [QueueTrigger("%FunctionExecutionCommands__QueueName%", Connection = "FunctionExecutionCommands__ConnectionString")] string message,
+            [QueueTrigger("%FunctionExecutionCommands:QueueName%", Connection = "FunctionExecutionCommands:ConnectionString")] string message,
             CancellationToken cancellationToken)
         {
             if (!this.options.Enabled)


### PR DESCRIPTION
Use colon-delimited configuration paths in the Azure Functions queue binding so the deployed double-underscore app settings resolve correctly.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
